### PR TITLE
Use main event loop to draw

### DIFF
--- a/oled.py
+++ b/oled.py
@@ -17,58 +17,40 @@ oFont24 = pygame.freetype.Font(fontPath, 24)
 oFont32 = pygame.freetype.Font(fontPath, 32)
 windowSize = (128*SCALERATIO,64*SCALERATIO)
 
-def createOled():
-    pygame.display.init() 
-
-    icon = pygame.image.load("assets/icon.png")
-    pygame.display.set_icon(icon)
-    pygame.display.set_caption('Organelle OLED')
-
-    while True:
-        event = pygame.event.wait()
-        if event.type == pygame.QUIT:
-            server.socket.close() #close server and let close the console
-            break
-
-
-t = threading.Thread(target=createOled)
-t.daemon = True
-t.start()
-
 s = pygame.Surface((128,64), pygame.SRCALPHA, 32)
 sWindow = pygame.Surface(windowSize, pygame.SRCALPHA, 32)
 screen = pygame.display.set_mode(windowSize)
 screen.fill((32,32,32))
 
-def gClear(unused_addr, unused_1):
+def gClear(unused_1):
     global s
     pygame.draw.rect(s, (32,32,32), (0, 0, 128, 64), 0)
 
-def gSetPixel(unused_addr, x, y, c):
+def gSetPixel(x, y, c):
     global s
     pygame.draw.line(s, (255,255,255) if c == 1 else (32,32,32), (x, y), (x, y))
 
-def gLine(unused_addr, x1, y1, x2, y2, c):
+def gLine(x1, y1, x2, y2, c):
     global s
     pygame.draw.line(s, (255,255,255) if c == 1 else (32,32,32), (x1, y1), (x2, y2))
 
-def gBox(unused_addr, x1, y1, x2, y2, c):
+def gBox(x1, y1, x2, y2, c):
     global s
     pygame.draw.rect(s, (255,255,255) if c == 1 else (32,32,32), (x1, y1, x2, y2), 1)
 
-def gFillArea(unused_addr, x1, y1, x2, y2, c):
+def gFillArea(x1, y1, x2, y2, c):
     global s
     pygame.draw.rect(s, (255,255,255) if c == 1 else (32,32,32), (x1, y1, x2, y2), 0)
 
-def gCircle(unused_addr, x, y, size, c):
+def gCircle(x, y, size, c):
     global s
     pygame.draw.circle(s, (255,255,255) if c == 1 else (32,32,32), (int(x), int(y)), int(size), 1)
 
-def gFilledCircle(unused_addr, x, y, size, c):
+def gFilledCircle(x, y, size, c):
     global s
     pygame.draw.circle(s, (255,255,255) if c == 1 else (32,32,32), (int(x), int(y)), int(size), 0)
 
-def gFlip(unused_addr):
+def gFlip():
     global s
     global screen
 
@@ -77,30 +59,30 @@ def gFlip(unused_addr):
     screen.blit(sWindow, (0, 0))
     pygame.display.flip()
 
-def gInvertArea(unused_addr, x, y, w, h): #/oled/gInvertArea 3 3 $1 121 9
+def gInvertArea(x, y, w, h): #/oled/gInvertArea 3 3 $1 121 9
     global s
     global screen
 
-    gFlip("unused_addr")
+    gFlip()
     inv = pygame.Surface((w, h), pygame.SRCALPHA)
     inv.fill((255,255,255,255))
     inv.blit(s, (- x, -y), None, pygame.BLEND_RGB_SUB)
     s.blit(inv, (x, y), None)
-    gFlip("unused_addr")
+    gFlip()
 
-def gInvertLine(unused_addr, n): #/oled/gInvertLine 0
+def gInvertLine(n): #/oled/gInvertLine 0
     if n == 0:
-        gInvertArea("unused_addr", 0, 8, 128, 9)
+        gInvertArea(0, 8, 128, 9)
     elif n == 1:
-        gInvertArea("unused_addr", 0, 20, 128, 9)
+        gInvertArea(0, 20, 128, 9)
     elif n == 2:
-        gInvertArea("unused_addr", 0, 32, 128, 9)
+        gInvertArea(0, 32, 128, 9)
     elif n == 3:
-        gInvertArea("unused_addr", 0, 44, 128, 9)
+        gInvertArea(0, 44, 128, 9)
     elif n == 4:
-        gInvertArea("unused_addr", 0, 56, 128, 9)
+        gInvertArea(0, 56, 128, 9)
 
-def gPrintln(unused_addr, x, y, size, c, *txtToPrint):
+def gPrintln(x, y, size, c, *txtToPrint):
     global s
     global oFont
 
@@ -120,19 +102,19 @@ def gPrintln(unused_addr, x, y, size, c, *txtToPrint):
     elif size == 32:
         oFont32.render_to(s, (x, y), txt, (255,255,255) if c == 1 else (32,32,32))
 
-def gCleanln(unused_addr, n):
+def gCleanln(n):
     if n == 1:
-        gFillArea("unused_addr", 0, 8, 128, 9, 0)
+        gFillArea(0, 8, 128, 9, 0)
     elif n == 2:
-        gFillArea("unused_addr", 0, 20, 128, 9, 0)
+        gFillArea(0, 20, 128, 9, 0)
     elif n == 3:
-        gFillArea("unused_addr", 0, 32, 128, 9, 0)
+        gFillArea(0, 32, 128, 9, 0)
     elif n == 4:
-        gFillArea("unused_addr", 0, 44, 128, 9, 0)
+        gFillArea(0, 44, 128, 9, 0)
     elif n == 5:
-        gFillArea("unused_addr", 0, 56, 128, 9, 0)
+        gFillArea(0, 56, 128, 9, 0)
 
-def gDrawInfoBar(unused_addr, inL, inR, outL, outR):
+def gDrawInfoBar(inL, inR, outL, outR):
     global s
     global oFont
 
@@ -159,47 +141,65 @@ def gDrawInfoBar(unused_addr, inL, inR, outL, outR):
     if outL > 11:
         outL = 11
 
-    gFillArea('unused_addr', 0, 0, 128, 8, 0)
+    gFillArea(0, 0, 128, 8, 0)
 
-    gPrintln("unused_addr", 0, 0, 8, 1, "I")
-    gPrintln("unused_addr", 64, 0, 8, 1, "O")
+    gPrintln(0, 0, 8, 1, "I")
+    gPrintln(64, 0, 8, 1, "O")
 
     for i in range(11):
-        gFillArea('unused_addr', (i * 5) + 8, 1, 1, 2, 1)
-        gFillArea('unused_addr', (i * 5) + 8, 5, 1, 2, 1)
+        gFillArea((i * 5) + 8, 1, 1, 2, 1)
+        gFillArea((i * 5) + 8, 5, 1, 2, 1)
     for i in range(inR):
-        gFillArea('unused_addr', (i * 5) + 7, 0, 3, 4, 1);
+        gFillArea((i * 5) + 7, 0, 3, 4, 1);
     for i in range(inL):
-        gFillArea('unused_addr', (i * 5) + 7, 4, 3, 4, 1);
+        gFillArea((i * 5) + 7, 4, 3, 4, 1);
 
     for i in range(11):
-        gFillArea('unused_addr', (i * 5) + 74, 1, 1, 2, 1)
-        gFillArea('unused_addr', (i * 5) + 74, 5, 1, 2, 1)
+        gFillArea((i * 5) + 74, 1, 1, 2, 1)
+        gFillArea((i * 5) + 74, 5, 1, 2, 1)
     for i in range(outR):
-        gFillArea('unused_addr', (i * 5) + 73, 0, 3, 4, 1);
+        gFillArea((i * 5) + 73, 0, 3, 4, 1);
     for i in range(outL):
-        gFillArea('unused_addr', (i * 5) + 73, 4, 3, 4, 1);
+        gFillArea((i * 5) + 73, 4, 3, 4, 1);
 
-    gFlip("unused_addr")
+    gFlip()
 
+GDRAW = pygame.event.custom_type()
+
+def gDrawevent(dummy, func, *args):
+    pygame.event.post(pygame.event.Event(GDRAW, { 'func': func[0], 'args': args}))
 
 dispatcher = dispatcher.Dispatcher()
-dispatcher.map("/gClear", gClear)
-dispatcher.map("/gFlip", gFlip)
-dispatcher.map("/gSetPixel", gSetPixel)
-dispatcher.map("/gLine", gLine)
-dispatcher.map("/gBox", gBox)
-dispatcher.map("/gFillArea", gFillArea)
-dispatcher.map("/gCircle", gCircle)
-dispatcher.map("/gFilledCircle", gFilledCircle)
-dispatcher.map("/gPrintln", gPrintln)
-dispatcher.map("/gCleanln", gCleanln)
-dispatcher.map("/gInvertArea", gInvertArea)
-dispatcher.map("/gInvertLine", gInvertLine)
-dispatcher.map("/gDrawInfoBar", gDrawInfoBar)
+dispatcher.map("/gClear", gDrawevent, gClear)
+dispatcher.map("/gFlip", gDrawevent, gFlip)
+dispatcher.map("/gSetPixel", gDrawevent, gSetPixel)
+dispatcher.map("/gLine", gDrawevent, gLine)
+dispatcher.map("/gBox", gDrawevent, gBox)
+dispatcher.map("/gFillArea", gDrawevent, gFillArea)
+dispatcher.map("/gCircle", gDrawevent, gCircle)
+dispatcher.map("/gFilledCircle", gDrawevent, gFilledCircle)
+dispatcher.map("/gPrintln", gDrawevent, gPrintln)
+dispatcher.map("/gCleanln", gDrawevent, gCleanln)
+dispatcher.map("/gInvertArea", gDrawevent, gInvertArea)
+dispatcher.map("/gInvertLine", gDrawevent, gInvertLine)
+dispatcher.map("/gDrawInfoBar", gDrawevent, gDrawInfoBar)
 
 
 server = osc_server.ThreadingOSCUDPServer(("localhost", 3000), dispatcher)
 print("Serving on {}".format(server.server_address))
-server.serve_forever()
-    
+t = threading.Thread(target=server.serve_forever)
+t.daemon = True
+t.start()
+
+icon = pygame.image.load("assets/icon.png")
+pygame.display.set_icon(icon)
+pygame.display.set_caption('Organelle OLED')
+
+while True:
+    event = pygame.event.wait()
+    if event.type == pygame.QUIT:
+        server.socket.close() #close server and let close the console
+        break
+    elif event.type == GDRAW:
+        event.func(*event.args)
+


### PR DESCRIPTION
On MacOs only the main thread/event loop can draw to the screen.
This puts the osc server in the new thread, and sends the drawing instructions to the main thread as instances of a new pygame event type.
closes #1 